### PR TITLE
Fix util conversion to LSIF v4 and re-enable unit tests

### DIFF
--- a/util/.vscode/launch.json
+++ b/util/.vscode/launch.json
@@ -13,7 +13,7 @@
 				"${workspaceFolder}/lib/**/*.js"
             ],
             "sourceMaps": true,
-            "args": [ "visualize", ".\\example\\json.json", "--id", "2", "--inputFormat=json" ]
+            "args": [ "visualize", ".\\example\\json.json", "--inV", "2", "--inputFormat=json" ]
         },
         {
             "type": "node",

--- a/util/package-lock.json
+++ b/util/package-lock.json
@@ -1629,7 +1629,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1650,12 +1651,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1670,17 +1673,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1797,7 +1803,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1809,6 +1816,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1823,6 +1831,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1830,12 +1839,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1854,6 +1865,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1934,7 +1946,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1946,6 +1959,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2031,7 +2045,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2067,6 +2082,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2086,6 +2102,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2129,12 +2146,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/util/package.json
+++ b/util/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lsif-util",
-	"version": "1.0.0",
+	"version": "0.2.0",
 	"description": "Utility tools for LSIF development.",
 	"main": "./lib/main.js",
 	"repository": {

--- a/util/package.json
+++ b/util/package.json
@@ -40,7 +40,7 @@
 	"dependencies": {
 		"fs-extra": "^7.0.1",
 		"jsonschema": "^1.2.4",
-		"lsif-protocol": "0.4.0",
+		"lsif-protocol": "^0.4.0",
 		"readline": "^1.3.0",
 		"typescript-json-schema": "^0.36.0",
 		"yargs": "^13.2.4"

--- a/util/src/filter.ts
+++ b/util/src/filter.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as LSIF from 'lsif-protocol';
-import { Edge, ElementTypes } from 'lsif-protocol';
 
 export interface IFilter {
 	id: string[];
@@ -27,15 +26,15 @@ export function getFilteredIds(argv: IFilter, input: LSIF.Element[]): string[] {
 	result = result.filter((element: LSIF.Element) => includes(id, element.id));
 	result = result.filter((element: LSIF.Element) => {
 		/* ToDo@jumattos The element is a vertex here as well. Uncomment the if and test are failing*/
-		if (element.type !== ElementTypes.edge) {
+		if (element.type !== LSIF.ElementTypes.edge) {
 			return false;
 		}
-		let edge: Edge = element as Edge;
-		if (Edge.is11(edge)) {
+		const edge: LSIF.Edge = element as LSIF.Edge;
+		if (LSIF.Edge.is11(edge)) {
 			return includes(inV, edge.inV);
 		} else {
 			console.log(JSON.stringify(edge, undefined, 0));
-			for (let item of edge.inVs) {
+			for (const item of edge.inVs) {
 				if (includes(inV, item)) {
 					return true;
 				}

--- a/util/src/filter.ts
+++ b/util/src/filter.ts
@@ -25,15 +25,15 @@ export function getFilteredIds(argv: IFilter, input: LSIF.Element[]): string[] {
 
 	result = result.filter((element: LSIF.Element) => includes(id, element.id));
 	result = result.filter((element: LSIF.Element) => {
-		/* ToDo@jumattos The element is a vertex here as well. Uncomment the if and test are failing*/
-		if (element.type !== LSIF.ElementTypes.edge) {
+		if (inV.length === 0) {
+			return true;
+		} else if (element.type !== LSIF.ElementTypes.edge) {
 			return false;
 		}
 		const edge: LSIF.Edge = element as LSIF.Edge;
 		if (LSIF.Edge.is11(edge)) {
 			return includes(inV, edge.inV);
 		} else {
-			console.log(JSON.stringify(edge, undefined, 0));
 			for (const item of edge.inVs) {
 				if (includes(inV, item)) {
 					return true;

--- a/util/src/main.ts
+++ b/util/src/main.ts
@@ -45,44 +45,56 @@ export function main(): void {
 	.usage('Usage: $0 [validate|visualize] [file] --inputFormat=[line|json] [filters]')
 
 	// Validation tool
-	.command('validate [file]', '', (argv: yargs.Argv) => argv
-		.positional('file', {
+	.command('validate [file]', '',
+	{
+		file: {
 			describe: 'Path to input file or --stdin',
-		}) as any /* ToDo@jumattos */,  (argv: yargs.Arguments<{ stdin: boolean; file: string; inputFormat: string }>) => {
-			if (!argv.stdin && argv.file === undefined) {
-				yargs.showHelp('log');
-				console.error('\nError: Missing input file. Did you forget --stdin?');
-				process.exitCode = 1;
-			} else {
-				readInput(argv.inputFormat, argv.stdin ? '--stdin' : argv.file, (input: LSIF.Element[]) => {
+			type: 'string',
+		},
+	}, (argv: yargs.Arguments) => {
+		if (!argv.stdin && argv.file === undefined) {
+			yargs.showHelp('log');
+			console.error('\nError: Missing input file. Did you forget --stdin?');
+			process.exitCode = 1;
+		} else {
+			readInput(
+				argv.inputFormat as string,
+				argv.stdin ? '--stdin' : argv.file as string,
+				(input: LSIF.Element[]) => {
 					const filter: IFilter = argv as unknown as IFilter;
-					process.exitCode = validate(input, getFilteredIds(filter, input),
-												path.join(path.dirname(process.argv[1]),
-														'../node_modules/lsif-protocol/lib/protocol.d.ts'));
+					process.exitCode = validate(
+						input, getFilteredIds(filter, input),
+						path.join(path.dirname(process.argv[1]),
+						'../node_modules/lsif-protocol/lib/protocol.d.ts'));
 				});
-			}
-		})
+		}
+	})
 
 	// Visualization tool
-	.command('visualize [file]', '', (argv: yargs.Argv) => argv
-		.positional('file', {
-			describe: 'Path to input file or --stdin',
-		})
-		.option('distance', {
+	.command('visualize [file]', '',
+	{
+		distance: {
 			default: 1,
+			demandOption: false,
 			describe: 'Max distance between any vertex and the filtered input',
-		}) as any /* ToDo@jumattos */, (argv: yargs.Arguments<{ stdin: boolean; file: string; inputFormat: string; distance: number }>) => {
-			if (!argv.stdin && argv.file === undefined) {
-				yargs.showHelp('log');
-				console.error('\nError: Missing input file. Did you forget --stdin?');
-				process.exitCode = 1;
-			} else {
-				readInput(argv.inputFormat, argv.stdin ? '--stdin' : argv.file, (input: LSIF.Element[]) => {
-					const filter: IFilter = argv as unknown as IFilter;
-					process.exitCode = visualize(input, getFilteredIds(filter, input), argv.distance);
-				});
-			}
-		})
+			type: 'number',
+		},
+		file: {
+			describe: 'Path to input file or --stdin',
+			type: 'string',
+		},
+	}, (argv: yargs.Arguments) => {
+		if (!argv.stdin && argv.file === undefined) {
+			yargs.showHelp('log');
+			console.error('\nError: Missing input file. Did you forget --stdin?');
+			process.exitCode = 1;
+		} else {
+			readInput(argv.inputFormat as string, argv.stdin ? '--stdin' : argv.file as string, (input: LSIF.Element[]) => {
+				const filter: IFilter = argv as unknown as IFilter;
+				process.exitCode = visualize(input, getFilteredIds(filter, input), argv.distance as number);
+			});
+		}
+	})
 
 	// One and only one command should be specified
 	.demandCommand(1, 1)

--- a/util/src/main.ts
+++ b/util/src/main.ts
@@ -63,9 +63,9 @@ export function main(): void {
 				(input: LSIF.Element[]) => {
 					const filter: IFilter = argv as unknown as IFilter;
 					process.exitCode = validate(
-						input, getFilteredIds(filter, input),
-						path.join(path.dirname(process.argv[1]),
-						'../node_modules/lsif-protocol/lib/protocol.d.ts'));
+						input,
+						getFilteredIds(filter, input),
+						path.join(path.dirname(process.argv[1]), '../node_modules/lsif-protocol/lib/protocol.d.ts'));
 				});
 		}
 	})

--- a/util/src/test/filter.ts
+++ b/util/src/test/filter.ts
@@ -62,21 +62,21 @@ const mockInput = [
 ];
 
 describe('The filters', () => {
-	// it('Should return the whole input if no filter is specified', () => {
-	// 	const ids: string[] = getFilteredIds(emptyFilter, mockInput);
-	// 	expect(ids.length)
-	// 	.toEqual(mockInput.length);
-	// 	mockInput.forEach((element: LSIF.Element) => expect(ids)
-	// 	.toContain(element.id));
-	// });
-	// it('Should filter by id', () => {
-	// 	const filter: IFilter = { ...emptyFilter, id: ['1', '2'] };
-	// 	const ids: string[] = getFilteredIds(filter, mockInput);
-	// 	expect(ids.length)
-	// 	.toEqual(filter.id.length);
-	// 	filter.id.forEach((id: string) => expect(ids)
-	// 	.toContain(id));
-	// });
+	it('Should return the whole input if no filter is specified', () => {
+		const ids: string[] = getFilteredIds(emptyFilter, mockInput);
+		expect(ids.length)
+		.toEqual(mockInput.length);
+		mockInput.forEach((element: LSIF.Element) => expect(ids)
+		.toContain(element.id));
+	});
+	it('Should filter by id', () => {
+		const filter: IFilter = { ...emptyFilter, id: ['1', '2'] };
+		const ids: string[] = getFilteredIds(filter, mockInput);
+		expect(ids.length)
+		.toEqual(filter.id.length);
+		filter.id.forEach((id: string) => expect(ids)
+		.toContain(id));
+	});
 	it('Should filter by inV', () => {
 		const filter: IFilter = { ...emptyFilter, inV: ['2'] };
 		const ids: string[] = getFilteredIds(filter, mockInput);
@@ -85,48 +85,48 @@ describe('The filters', () => {
 		expect(ids)
 		.toContain('4');
 	});
-	// it('Should filter by outV', () => {
-	// 	const filter: IFilter = { ...emptyFilter, outV: ['1'] };
-	// 	const ids: string[] = getFilteredIds(filter, mockInput);
-	// 	expect(ids.length)
-	// 	.toEqual(2);
-	// 	expect(ids)
-	// 	.toContain('4');
-	// 	expect(ids)
-	// 	.toContain('5');
-	// });
-	// it('Should filter by label', () => {
-	// 	const filter: IFilter = { ...emptyFilter, label: ['range'] };
-	// 	const ids: string[] = getFilteredIds(filter, mockInput);
-	// 	expect(ids.length)
-	// 	.toEqual(2);
-	// 	expect(ids)
-	// 	.toContain('2');
-	// 	expect(ids)
-	// 	.toContain('3');
-	// });
-	// it('Should filter by property', () => {
-	// 	const filter: IFilter = { ...emptyFilter, property: ['references'] };
-	// 	const ids: string[] = getFilteredIds(filter, mockInput);
-	// 	expect(ids.length)
-	// 	.toEqual(1);
-	// 	expect(ids)
-	// 	.toContain('7');
-	// });
-	// it('Should filter by regex', () => {
-	// 	const filter: IFilter = { ...emptyFilter, regex: 'foo' };
-	// 	const ids: string[] = getFilteredIds(filter, mockInput);
-	// 	expect(ids.length)
-	// 	.toEqual(1);
-	// 	expect(ids)
-	// 	.toContain('3');
-	// });
-	// it('Should be able to combine filters', () => {
-	// 	const filter: IFilter = { ...emptyFilter, regex: 'foo', label: ['range'] };
-	// 	const ids: string[] = getFilteredIds(filter, mockInput);
-	// 	expect(ids.length)
-	// 	.toEqual(1);
-	// 	expect(ids)
-	// 	.toContain('3');
-	// });
+	it('Should filter by outV', () => {
+		const filter: IFilter = { ...emptyFilter, outV: ['1'] };
+		const ids: string[] = getFilteredIds(filter, mockInput);
+		expect(ids.length)
+		.toEqual(2);
+		expect(ids)
+		.toContain('4');
+		expect(ids)
+		.toContain('5');
+	});
+	it('Should filter by label', () => {
+		const filter: IFilter = { ...emptyFilter, label: ['range'] };
+		const ids: string[] = getFilteredIds(filter, mockInput);
+		expect(ids.length)
+		.toEqual(2);
+		expect(ids)
+		.toContain('2');
+		expect(ids)
+		.toContain('3');
+	});
+	it('Should filter by property', () => {
+		const filter: IFilter = { ...emptyFilter, property: ['references'] };
+		const ids: string[] = getFilteredIds(filter, mockInput);
+		expect(ids.length)
+		.toEqual(1);
+		expect(ids)
+		.toContain('7');
+	});
+	it('Should filter by regex', () => {
+		const filter: IFilter = { ...emptyFilter, regex: 'foo' };
+		const ids: string[] = getFilteredIds(filter, mockInput);
+		expect(ids.length)
+		.toEqual(1);
+		expect(ids)
+		.toContain('3');
+	});
+	it('Should be able to combine filters', () => {
+		const filter: IFilter = { ...emptyFilter, regex: 'foo', label: ['range'] };
+		const ids: string[] = getFilteredIds(filter, mockInput);
+		expect(ids.length)
+		.toEqual(1);
+		expect(ids)
+		.toContain('3');
+	});
 });

--- a/util/src/validate.ts
+++ b/util/src/validate.ts
@@ -5,7 +5,6 @@
 import * as fse from 'fs-extra';
 import { validate as validateSchema, ValidationError, ValidatorResult } from 'jsonschema';
 import * as LSIF from 'lsif-protocol';
-import { Edge, ElementTypes, Id } from 'lsif-protocol';
 import * as TJS from 'typescript-json-schema';
 
 const vertices: { [id: string]: Element } = {};
@@ -89,11 +88,11 @@ function readInput(toolOutput: LSIF.Element[]): void {
 	process.stdout.write(`${outputMessage}\r`);
 
 	for (const object of toolOutput) {
-		if (object.type === ElementTypes.edge) {
+		if (object.type === LSIF.ElementTypes.edge) {
 			const edge: LSIF.Edge = object as LSIF.Edge;
 			edges[edge.id.toString()] = new Element(edge);
 
-			const handleEdge = (outV: Id, inV: Id) => {
+			const handleEdge = (outV: LSIF.Id, inV: LSIF.Id) => {
 				if (inV === undefined || outV === undefined) {
 					errors.push(new Error(edge, `requires properties "inV" and "outV"`));
 					edges[edge.id.toString()].invalidate();
@@ -108,7 +107,7 @@ function readInput(toolOutput: LSIF.Element[]): void {
 
 				visited[inV.toString()] = visited[outV.toString()] = true;
 			};
-			if (Edge.is11(edge)) {
+			if (LSIF.Edge.is11(edge)) {
 				handleEdge(edge.outV, edge.inV);
 			} else {
 				edge.inVs.forEach ((inV) => handleEdge(edge.outV, inV));
@@ -201,8 +200,8 @@ function checkEdges(ids: string[], protocolPath: string): void {
 			let errorMessage: string | undefined;
 			edges[key].invalidate();
 
-			if ((Edge.is11(edge) && edge.inV === undefined) ||
-				Edge.is1N(edge) && edge.inVs === undefined || edge.outV === undefined) {
+			if ((LSIF.Edge.is11(edge) && edge.inV === undefined) ||
+				LSIF.Edge.is1N(edge) && edge.inVs === undefined || edge.outV === undefined) {
 				// This error was caught before
 				return;
 			}

--- a/util/src/validate.ts
+++ b/util/src/validate.ts
@@ -30,8 +30,8 @@ class Error {
 
 	public print(): void {
 		console.error(
-			`\n${this.element.type.toUpperCase()} ${this.element.id}:
-			FAIL> ${this.message}\n${JSON.stringify(this.element, undefined, 2)}`,
+			`\n${this.element.type.toUpperCase()} ${this.element.id}: ` +
+			`FAIL> ${this.message}\n${JSON.stringify(this.element, undefined, 2)}`,
 		);
 	}
 }
@@ -240,12 +240,12 @@ function printOutput(ids: string[]): void {
 	console.log();
 
 	const verticesStats: Statistics = getStatistics(vertices, ids);
-	console.log(`Vertices:\t${verticesStats.passed} passed,
-				${verticesStats.failed} failed, ${verticesStats.total} total`);
+	console.log(`Vertices:\t${verticesStats.passed} passed, ` +
+				`${verticesStats.failed} failed, ${verticesStats.total} total`);
 
 	const edgesStats: Statistics = getStatistics(edges, ids);
-	console.log(`Edges:\t\t${edgesStats.passed} passed,
-				${edgesStats.failed} failed, ${edgesStats.total} total`);
+	console.log(`Edges:\t\t${edgesStats.passed} passed, ` +
+				`${edgesStats.failed} failed, ${edgesStats.total} total`);
 
 	errors.forEach((e: Error) => {
 		// Only print error for the elements verified

--- a/util/src/visualize.ts
+++ b/util/src/visualize.ts
@@ -18,7 +18,7 @@ export function visualize(toolOutput: LSIF.Element[], ids: string[], distance: n
 			if (Edge.is11(edge)) {
 				idQueue.push(edge.inV.toString(), edge.outV.toString());
 			} else {
-				for (let inV of edge.inVs) {
+				for (const inV of edge.inVs) {
 					idQueue.push(inV.toString(), edge.outV.toString());
 				}
 			}
@@ -51,7 +51,8 @@ export function visualize(toolOutput: LSIF.Element[], ids: string[], distance: n
 	Object.keys(edges)
 	.forEach((key: string) => {
 		const edge: LSIF.Edge = edges[key] as LSIF.Edge;
-		const inV: LSIF.Element = toolOutput.filter((element: LSIF.Element) => Edge.is11(edge) ? element.id === edge.inV : edge.inVs.indexOf(element.id) !== -1)[0];
+		const inV: LSIF.Element = toolOutput.filter((element: LSIF.Element) =>
+													Edge.is11(edge) ? element.id === edge.inV : edge.inVs.indexOf(element.id) !== -1)[0];
 		const outV: LSIF.Element = toolOutput.filter((element: LSIF.Element) => element.id === edge.outV)[0];
 
 		vertices[inV.id.toString()] = inV;
@@ -97,7 +98,7 @@ function printDOT(edges: { [id: string]: LSIF.Element }, vertices: { [id: string
 		if (Edge.is11(edge)) {
 			digraph += `  ${edge.outV} -> ${edge.inV} [label="${edge.label}"]\n`;
 		} else {
-			for (let inV of edge.inVs) {
+			for (const inV of edge.inVs) {
 				digraph += `  ${edge.outV} -> ${inV} [label="${edge.label}"]\n`;
 			}
 		}

--- a/util/tslint.json
+++ b/util/tslint.json
@@ -16,6 +16,7 @@
 		"no-reserved-keywords": false,
 		"ban-comma-operator": false,
 		"quotemark": [true, "single"],
-		"max-classes-per-file": false
+		"max-classes-per-file": false,
+		"indent": [true, "tabs"]
 	}
 }


### PR DESCRIPTION
Fixed bug where vertices wouldn't be filtered correctly since they were being treated as edges.

Validation still needs work before the next release of the package. I opened [this issue](https://github.com/microsoft/lsif-node/issues/52) to clarify on what is valid and what is not when it comes to retro compatibility.