### PR TITLE
[lsif-util] Use __dirname to find path to installed lsif-util

### DIFF
--- a/util/src/main.ts
+++ b/util/src/main.ts
@@ -57,8 +57,8 @@ export function main(): void {
 				readInput(argv.inputFormat, argv.stdin ? '--stdin' : argv.file, (input: LSIF.Element[]) => {
 					const filter: IFilter = argv as unknown as IFilter;
 					process.exitCode = validate(input, getFilteredIds(filter, input),
-												path.join(path.dirname(process.argv[1]),
-														'../node_modules/lsif-protocol/lib/protocol.d.ts'));
+												path.join(__dirname,
+													'../node_modules/lsif-protocol/lib/protocol.d.ts'));
 				});
 			}
 		})


### PR DESCRIPTION
This fixes #51 