### PR TITLE
LSIF v4 util validation fixes

### DIFF
--- a/util/example/json.json
+++ b/util/example/json.json
@@ -25,7 +25,7 @@
    "type": "edge",
    "label": "contains",
    "outV": 1,
-   "inV": 3
+   "inVs": [ 3 ]
 }, {
    "id": 6,
    "type": "vertex",
@@ -36,5 +36,6 @@
    "label": "item",
    "property": "references",
    "outV": 6,
-   "inV": 3
+   "inVs": [ 3 ],
+   "document": "1"
 }]

--- a/util/example/json.json
+++ b/util/example/json.json
@@ -1,41 +1,53 @@
-[{
-   "id": 1,
-   "type": "vertex",
-   "label": "document",
-   "contents": "THISTERRIBLESTRINGISLONGANDUGLYANDWEDONTWANTTOSEEITINOURGRAPHNOMATTERWHAT"
-}, {
-   "id": 2,
-   "type": "vertex",
-   "label": "range"
-}, {
-   "id": 3,
-   "type": "vertex",
-   "label": "range",
-   "tag": {
-       "text": "foo"
+[
+   {
+      "id":1,
+      "type":"vertex",
+      "label":"document",
+      "contents":"THISTERRIBLESTRINGISLONGANDUGLYANDWEDONTWANTTOSEEITINOURGRAPHNOMATTERWHAT"
+   },
+   {
+      "id":2,
+      "type":"vertex",
+      "label":"range"
+   },
+   {
+      "id":3,
+      "type":"vertex",
+      "label":"range",
+      "tag":{
+         "text":"foo"
+      }
+   },
+   {
+      "id":4,
+      "type":"edge",
+      "label":"contains",
+      "outV":1,
+      "inV":2
+   },
+   {
+      "id":5,
+      "type":"edge",
+      "label":"contains",
+      "outV":1,
+      "inVs":[
+         3
+      ]
+   },
+   {
+      "id":6,
+      "type":"vertex",
+      "label":"referenceResult"
+   },
+   {
+      "id":7,
+      "type":"edge",
+      "label":"item",
+      "property":"references",
+      "outV":6,
+      "inVs":[
+         3
+      ],
+      "document":"1"
    }
-}, {
-   "id": 4,
-   "type": "edge",
-   "label": "contains",
-   "outV": 1,
-   "inV": 2
-}, {
-   "id": 5,
-   "type": "edge",
-   "label": "contains",
-   "outV": 1,
-   "inVs": [ 3 ]
-}, {
-   "id": 6,
-   "type": "vertex",
-   "label": "referenceResult"
-}, {
-   "id": 7,
-   "type": "edge",
-   "label": "item",
-   "property": "references",
-   "outV": 6,
-   "inVs": [ 3 ],
-   "document": "1"
-}]
+]

--- a/util/example/line.json
+++ b/util/example/line.json
@@ -4,4 +4,4 @@
 { "id": 4, "type": "edge", "label": "contains", "outV": 1, "inV": 2 }
 { "id": 5, "type": "edge", "label": "contains", "outV": 1, "inVs": [ 3 ] }
 { "id": 6, "type": "vertex", "label": "referenceResult" }
-{ "id": 7, "type": "edge", "label": "item", "property": "references", "outV": 6, "inVs": [3], "document": "1" }
+{ "id": 7, "type": "edge", "label": "item", "property": "references", "outV": 6, "inVs": [ 3 ], "document": "1" }

--- a/util/example/line.json
+++ b/util/example/line.json
@@ -4,4 +4,4 @@
 { "id": 4, "type": "edge", "label": "contains", "outV": 1, "inV": 2 }
 { "id": 5, "type": "edge", "label": "contains", "outV": 1, "inV": 3 }
 { "id": 6, "type": "vertex", "label": "referenceResult" }
-{ "id": 7, "type": "edge", "label": "item", "property": "references", "outV": 6, "inV": 3 }
+{ "id": 7, "type": "edge", "label": "item", "property": "references", "outV": 6, "inVs": [3] }

--- a/util/example/line.json
+++ b/util/example/line.json
@@ -2,6 +2,6 @@
 { "id": 2, "type": "vertex", "label": "range" }
 { "id": 3, "type": "vertex", "label": "range", "tag": { "text": "foo" } }
 { "id": 4, "type": "edge", "label": "contains", "outV": 1, "inV": 2 }
-{ "id": 5, "type": "edge", "label": "contains", "outV": 1, "inV": 3 }
+{ "id": 5, "type": "edge", "label": "contains", "outV": 1, "inVs": [ 3 ] }
 { "id": 6, "type": "vertex", "label": "referenceResult" }
-{ "id": 7, "type": "edge", "label": "item", "property": "references", "outV": 6, "inVs": [3] }
+{ "id": 7, "type": "edge", "label": "item", "property": "references", "outV": 6, "inVs": [3], "document": "1" }

--- a/util/src/main.ts
+++ b/util/src/main.ts
@@ -19,8 +19,10 @@ function readInput(format: string, inputPath: string, callback: (input: LSIF.Ele
 	}
 
 	let input: LSIF.Element[] = [];
+	const invalidLines: string[] = [];
 	const buffer: string[] = [];
 	const rd: readline.Interface = readline.createInterface(inputStream);
+
 	rd.on('line', (line: string) => {
 		switch (format) {
 			case 'json':
@@ -31,19 +33,22 @@ function readInput(format: string, inputPath: string, callback: (input: LSIF.Ele
 					const element: LSIF.Element = JSON.parse(line);
 					input.push(element);
 				} catch {
-					// Do nothing for now
+					invalidLines.push(line);
 				}
 		}
 	});
 
 	rd.on('close', () => {
-		if (buffer.length > 0) {
-			input = JSON.parse(buffer.join('\n'));
-		} else if (input.length === 0) {
+		if (invalidLines.length > 0) {
 			yargs.showHelp('log');
-			console.error('\nError: Fail to parse input file. Did you forget --inputFormat=json?');
+			console.error('\nError: The following lines failed to parse. Did you forget --inputFormat=json?');
+			console.error(invalidLines.join('\n'));
 			process.exitCode = 1;
 			return;
+		}
+
+		if (buffer.length > 0) {
+			input = JSON.parse(buffer.join('\n'));
 		}
 
 		callback(input);

--- a/util/src/main.ts
+++ b/util/src/main.ts
@@ -27,13 +27,23 @@ function readInput(format: string, inputPath: string, callback: (input: LSIF.Ele
 				buffer.push(line);
 				break;
 			case 'line': default:
-				input.push(JSON.parse(line));
+				try {
+					const element: LSIF.Element = JSON.parse(line);
+					input.push(element);
+				} catch {
+					// Do nothing for now
+				}
 		}
 	});
 
 	rd.on('close', () => {
 		if (buffer.length > 0) {
 			input = JSON.parse(buffer.join('\n'));
+		} else if (input.length === 0) {
+			yargs.showHelp('log');
+			console.error('\nError: Fail to parse input file. Did you forget --inputFormat=json?');
+			process.exitCode = 1;
+			return;
 		}
 
 		callback(input);
@@ -63,8 +73,8 @@ export function main(): void {
 				(input: LSIF.Element[]) => {
 					const filter: IFilter = argv as unknown as IFilter;
 					process.exitCode = validate(
-                        input,
-                        getFilteredIds(filter, input),
+						input,
+						getFilteredIds(filter, input),
 						path.join(__dirname, '../node_modules/lsif-protocol/lib/protocol.d.ts'));
 				});
 		}

--- a/util/src/shared.ts
+++ b/util/src/shared.ts
@@ -1,0 +1,17 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import * as LSIF from 'lsif-protocol';
+
+export function getInVs(edge: LSIF.Edge): string[] {
+	const inVs: string[] = [];
+	if (LSIF.Edge.is11(edge)) {
+		inVs.push(edge.inV.toString());
+	} else {
+		for (const inV of edge.inVs) {
+			inVs.push(inV.toString());
+		}
+	}
+	return inVs;
+}

--- a/util/src/validate.ts
+++ b/util/src/validate.ts
@@ -64,11 +64,11 @@ class Statistics {
 }
 
 export function validate(toolOutput: LSIF.Element[], ids: string[], protocolPath: string): number {
-	readInput(toolOutput);
-
-	checkAllVisited();
-
 	if (fse.pathExistsSync(protocolPath)) {
+		readInput(toolOutput);
+
+		checkAllVisited();
+
 		checkVertices(toolOutput.filter((e: LSIF.Element) => e.type === 'vertex')
 								.map((e: LSIF.Element) => e.id.toString()),
 								protocolPath);
@@ -76,7 +76,8 @@ export function validate(toolOutput: LSIF.Element[], ids: string[], protocolPath
 								.map((e: LSIF.Element) => e.id.toString()),
 								protocolPath);
 	} else {
-		console.warn(`Skipping thorough validation: ${protocolPath} was not found`);
+		console.error(`Error: ${protocolPath} was not found`);
+		return 1;
 	}
 
 	printOutput(ids);

--- a/util/src/validate.ts
+++ b/util/src/validate.ts
@@ -181,6 +181,7 @@ function checkVertices(ids: string[], protocolPath: string): void {
 					});
 				} catch {
 					// Failed to get more details for the error
+					errorMessage = 'unable to provide details';
 				}
 			}
 			errors.push(new Error(vertex, errorMessage!));

--- a/util/src/validate.ts
+++ b/util/src/validate.ts
@@ -173,13 +173,7 @@ function checkVertices(ids: string[], protocolPath: string): void {
 					const className: string = vertex.label[0].toUpperCase() + vertex.label.slice(1);
 					const specificSchema: TJS.Definition | null = TJS.generateSchema(program, className, { required: true });
 					const moreValidation: ValidatorResult | null = validateSchema(vertex, specificSchema);
-					errorMessage = '';
-					moreValidation.errors.forEach((error: ValidationError, index: number) => {
-						if (index > 0) {
-							errorMessage += '; ';
-						}
-						errorMessage += `${error.message}`;
-					});
+					errorMessage = moreValidation.errors.join('; ');
 				} catch {
 					// Failed to get more details for the error
 					errorMessage = 'unable to provide details';
@@ -236,16 +230,7 @@ function checkEdges(ids: string[], protocolPath: string): void {
 		const validationErrors: ValidationError[] = validation.errors.filter((error) => error.property === 'instance');
 		if (validationErrors.length > 0) {
 			edges[key].invalidate();
-			let errorMessage: string = '';
-
-			validationErrors.forEach((error: ValidationError, index: number) => {
-				if (index > 0) {
-					errorMessage += '; ';
-				}
-				errorMessage += `${error.message}`;
-			});
-
-			errors.push(new Error(edges[key].element, errorMessage));
+			errors.push(new Error(edges[key].element, validationErrors.join('; ')));
 		}
 	});
 

--- a/util/src/visualize.ts
+++ b/util/src/visualize.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as LSIF from 'lsif-protocol';
-import { getInVs } from 'shared';
+import { getInVs } from './shared';
 
 export function visualize(toolOutput: LSIF.Element[], ids: string[], distance: number): number {
 	const edges: { [id: string]: LSIF.Element } = {};

--- a/util/src/visualize.ts
+++ b/util/src/visualize.ts
@@ -3,20 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as LSIF from 'lsif-protocol';
-import { Edge } from 'lsif-protocol';
-
-function getInVs(edge: LSIF.Edge): string[] {
-	let inVs: string[] = [];
-	if (Edge.is11(edge)) {
-		inVs.push(edge.inV.toString());
-	}
-	else {
-		for (const inV of edge.inVs) {
-			inVs.push(inV.toString());
-		}
-	}
-	return inVs;
-}
+import { getInVs } from 'shared';
 
 export function visualize(toolOutput: LSIF.Element[], ids: string[], distance: number): number {
 	const edges: { [id: string]: LSIF.Element } = {};
@@ -43,7 +30,7 @@ export function visualize(toolOutput: LSIF.Element[], ids: string[], distance: n
 		allEdges.forEach((element: LSIF.Element) => {
 			const edge: LSIF.Edge = element as LSIF.Edge;
 			const outV: string = edge.outV.toString();
-			getInVs(edge).forEach (inV => {
+			getInVs(edge).forEach ((inV) => {
 				if (targetIds.includes(inV) || targetIds.includes(outV)) {
 					edges[edge.id] = edge;
 					idQueue.push(inV, outV);
@@ -58,7 +45,7 @@ export function visualize(toolOutput: LSIF.Element[], ids: string[], distance: n
 		const inVs: string[] = getInVs(edge);
 		const outV: LSIF.Element = toolOutput.filter((element: LSIF.Element) => element.id === edge.outV)[0];
 
-		toolOutput.filter((element: LSIF.Element) => inVs.includes(element.id.toString())).forEach(element => {
+		toolOutput.filter((element: LSIF.Element) => inVs.includes(element.id.toString())).forEach((element) => {
 			vertices[element.id.toString()] = element;
 		});
 		vertices[outV.id.toString()] = outV;
@@ -100,7 +87,7 @@ function printDOT(edges: { [id: string]: LSIF.Element }, vertices: { [id: string
 	Object.keys(edges)
 	.forEach((key: string) => {
 		const edge: LSIF.Edge = edges[key] as LSIF.Edge;
-		if (Edge.is11(edge)) {
+		if (LSIF.Edge.is11(edge)) {
 			digraph += `  ${edge.outV} -> ${edge.inV} [label="${edge.label}"]\n`;
 		} else {
 			for (const inV of edge.inVs) {


### PR DESCRIPTION
- Validation for 1:1 and 1:N edges
- Examples updated to LSIF v4
- Helpful message if input format is incorrect
- [Missing protocol.d.ts is now an error](https://github.com/microsoft/lsif-node/issues/55)

After this PR, "contains" and "item" 1:1 edges will no longer be considered valid.