### PR TITLE
Fix lsif-util compilation issue

### DIFF
--- a/util/package-lock.json
+++ b/util/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lsif-util",
-  "version": "1.0.0",
+  "version": "0.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -499,10 +499,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.13.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.13.tgz",
-      "integrity": "sha512-GFWH7e4Q/OGLAO545bupVju+nE1YtLSwYAdLfSzAXnTPqoqKoXCOEtB7Cluvg9B/h2nGLhyzCDyCInYvrOE2nw==",
-      "dev": true
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.2.tgz",
+      "integrity": "sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -3383,9 +3382,9 @@
       }
     },
     "lsif-protocol": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/lsif-protocol/-/lsif-protocol-0.4.0.tgz",
-      "integrity": "sha512-SDESdBHrn+bJvNiAIBgaiEF9MrMW5aSxxrj9t+3jFReGBlWpjm8CnfG+GIgwC6bhFjr3n+vpUWDO7xFPvhtvkw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/lsif-protocol/-/lsif-protocol-0.4.3.tgz",
+      "integrity": "sha512-VePb+EbdturiWmGw1dh7G7z7OmhT6aBzqU42cqJLEk2QTMTbnN6ySIp1IiffNmD9jLX3NAtNSz1c85zpcZN6pw==",
       "requires": {
         "vscode-languageserver-protocol": "^3.14.1"
       }

--- a/util/package.json
+++ b/util/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lsif-util",
-	"version": "0.2.0",
+	"version": "0.2.11",
 	"description": "Utility tools for LSIF development.",
 	"main": "./lib/main.js",
 	"repository": {
@@ -40,7 +40,7 @@
 	"dependencies": {
 		"fs-extra": "^7.0.1",
 		"jsonschema": "^1.2.4",
-		"lsif-protocol": "^0.4.0",
+		"lsif-protocol": "0.4.3",
 		"readline": "^1.3.0",
 		"typescript-json-schema": "^0.36.0",
 		"yargs": "^13.2.4"

--- a/util/package.json
+++ b/util/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lsif-util",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"description": "Utility tools for LSIF development.",
 	"main": "./lib/main.js",
 	"repository": {

--- a/util/package.json
+++ b/util/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lsif-util",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "Utility tools for LSIF development.",
 	"main": "./lib/main.js",
 	"repository": {
@@ -38,6 +38,7 @@
 		"tslint": "^5.14.0"
 	},
 	"dependencies": {
+		"@types/node": "^12.6.2",
 		"fs-extra": "^7.0.1",
 		"jsonschema": "^1.2.4",
 		"lsif-protocol": "0.4.3",

--- a/util/src/main.ts
+++ b/util/src/main.ts
@@ -4,7 +4,6 @@
  * ------------------------------------------------------------------------------------------ */
 import * as fse from 'fs-extra';
 import * as LSIF from 'lsif-protocol';
-import * as path from 'path';
 import * as readline from 'readline';
 import * as yargs from 'yargs';
 import { getFilteredIds, IFilter } from './filter';
@@ -77,10 +76,7 @@ export function main(): void {
 				argv.stdin ? '--stdin' : argv.file as string,
 				(input: LSIF.Element[]) => {
 					const filter: IFilter = argv as unknown as IFilter;
-					process.exitCode = validate(
-						input,
-						getFilteredIds(filter, input),
-						path.join(__dirname, '../node_modules/lsif-protocol/lib/protocol.d.ts'));
+					process.exitCode = validate(input, getFilteredIds(filter, input));
 				});
 		}
 	})

--- a/util/src/validate.ts
+++ b/util/src/validate.ts
@@ -12,6 +12,7 @@ import { getInVs } from './shared';
 const vertices: { [id: string]: Element } = {};
 const edges: { [id: string]: Element } = {};
 const visited: { [id: string]: boolean } = {};
+const protocolSubPath: string = 'lsif-protocol/lib/protocol.d.ts';
 
 const errors: Error[] = [];
 
@@ -64,26 +65,40 @@ class Statistics {
 	}
 }
 
-export function validate(toolOutput: LSIF.Element[], ids: string[], protocolPath: string): number {
-	if (fse.pathExistsSync(protocolPath)) {
+export function validate(toolOutput: LSIF.Element[], ids: string[]): number {
+	const nodeModulesPath: string | null = findNodeModulesPath();
+	if (nodeModulesPath !== null) {
 		readInput(toolOutput);
 
 		checkAllVisited();
 
 		checkVertices(toolOutput.filter((e: LSIF.Element) => e.type === 'vertex')
 								.map((e: LSIF.Element) => e.id.toString()),
-								protocolPath);
+								nodeModulesPath);
 		checkEdges(	toolOutput.filter((e: LSIF.Element) => e.type === 'edge')
 								.map((e: LSIF.Element) => e.id.toString()),
-								protocolPath);
+								nodeModulesPath);
 	} else {
-		console.error(`Error: ${protocolPath} was not found`);
+		console.error(`Error: protocol.d.ts was not found`);
 		return 1;
 	}
 
 	printOutput(ids);
 
 	return errors.length === 0 ? 0 : 1;
+}
+
+// Returns null if protocol.d.ts is not found
+function findNodeModulesPath(): string | null {
+	let nodeModulesPath: string = path.join(__dirname, '../node_modules');
+	// Package installed globally
+	if (fse.pathExistsSync(path.join(nodeModulesPath, protocolSubPath))) {
+		return nodeModulesPath;
+	}
+
+	// Package installed locally
+	nodeModulesPath = path.join(__dirname, '../..');
+	return fse.pathExistsSync(path.join(nodeModulesPath, protocolSubPath)) ? nodeModulesPath : null;
 }
 
 function readInput(toolOutput: LSIF.Element[]): void {
@@ -147,12 +162,12 @@ function checkAllVisited(): void {
 	});
 }
 
-function checkVertices(ids: string[], protocolPath: string): void {
+function checkVertices(ids: string[], nodeModulesPath: string): void {
 	let outputMessage: string | undefined;
 	const compilerOptions: TJS.CompilerOptions = {
-		baseUrl: path.join(path.dirname(protocolPath), '..\\..'),
+		baseUrl: nodeModulesPath,
 	};
-	const program: TJS.Program = TJS.getProgramFromFiles([protocolPath], compilerOptions);
+	const program: TJS.Program = TJS.getProgramFromFiles([path.join(nodeModulesPath, protocolSubPath)], compilerOptions);
 	const vertexSchema: TJS.Definition | null = TJS.generateSchema(program, 'Vertex', { required: true });
 	let count: number = 1;
 	const length: number = ids.length;
@@ -192,12 +207,12 @@ function checkVertices(ids: string[], protocolPath: string): void {
 	}
 }
 
-function checkEdges(ids: string[], protocolPath: string): void {
+function checkEdges(ids: string[], nodeModulesPath: string): void {
 	let outputMessage: string | undefined;
 	const compilerOptions: TJS.CompilerOptions = {
-		baseUrl: path.join(path.dirname(protocolPath), '..\\..'),
+		baseUrl: nodeModulesPath,
 	};
-	const program: TJS.Program = TJS.getProgramFromFiles([protocolPath], compilerOptions);
+	const program: TJS.Program = TJS.getProgramFromFiles([path.join(nodeModulesPath, protocolSubPath)], compilerOptions);
 	let count: number = 1;
 	const length: number = ids.length;
 

--- a/util/src/validate.ts
+++ b/util/src/validate.ts
@@ -5,6 +5,7 @@
 import * as fse from 'fs-extra';
 import { validate as validateSchema, ValidationError, ValidatorResult } from 'jsonschema';
 import * as LSIF from 'lsif-protocol';
+import * as path from 'path';
 import * as TJS from 'typescript-json-schema';
 import { getInVs } from './shared';
 
@@ -148,7 +149,10 @@ function checkAllVisited(): void {
 
 function checkVertices(ids: string[], protocolPath: string): void {
 	let outputMessage: string | undefined;
-	const program: TJS.Program = TJS.getProgramFromFiles([protocolPath]);
+	const compilerOptions: TJS.CompilerOptions = {
+		baseUrl: path.join(path.dirname(protocolPath), '..\\..'),
+	};
+	const program: TJS.Program = TJS.getProgramFromFiles([protocolPath], compilerOptions);
 	const vertexSchema: TJS.Definition | null = TJS.generateSchema(program, 'Vertex', { required: true });
 	let count: number = 1;
 	const length: number = ids.length;
@@ -190,7 +194,10 @@ function checkVertices(ids: string[], protocolPath: string): void {
 
 function checkEdges(ids: string[], protocolPath: string): void {
 	let outputMessage: string | undefined;
-	const program: TJS.Program = TJS.getProgramFromFiles([protocolPath]);
+	const compilerOptions: TJS.CompilerOptions = {
+		baseUrl: path.join(path.dirname(protocolPath), '..\\..'),
+	};
+	const program: TJS.Program = TJS.getProgramFromFiles([protocolPath], compilerOptions);
 	let count: number = 1;
 	const length: number = ids.length;
 


### PR DESCRIPTION
Quick fix for the latest version of lsif-util that was having problems finding node.

The issue was that when trying to compile "protocol.d.ts" at run time, the lsif-util tool would look at your current directory to find the dependencies. This quick fix adds `baseUrl` to the compiler options in order to point lsif-util to the right place. Additionally, it adds a function to look for the right `node_modules` folder, since the location is different for packages installed globally and locally.