### PR TITLE
Remove false invalids and vastly improve validation performance

### DIFF
--- a/util/package.json
+++ b/util/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lsif-util",
-	"version": "0.2.14",
+	"version": "0.2.15",
 	"description": "Utility tools for LSIF development.",
 	"main": "./lib/main.js",
 	"repository": {

--- a/util/package.json
+++ b/util/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lsif-util",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Utility tools for LSIF development.",
 	"main": "./lib/main.js",
 	"repository": {

--- a/util/src/main.ts
+++ b/util/src/main.ts
@@ -23,6 +23,10 @@ function readInput(format: string, inputPath: string, callback: (input: LSIF.Ele
 	const rd: readline.Interface = readline.createInterface(inputStream);
 
 	rd.on('line', (line: string) => {
+		if (line === '') {
+			return;
+		}
+
 		switch (format) {
 			case 'json':
 				buffer.push(line);

--- a/util/src/validate.ts
+++ b/util/src/validate.ts
@@ -154,7 +154,7 @@ function checkAllVisited(): void {
 	Object.keys(vertices)
 	.forEach((key: string) => {
 		const vertex: LSIF.Vertex = vertices[key].element as LSIF.Vertex;
-		if (!visited[key] && vertex.label !== 'metaData') {
+		if (!visited[key] && vertex.label !== 'metaData' && vertex.label !== '$event') {
 			errors.push(new Error(vertex, `not connected to any other vertex`));
 			checks[Check.allVerticesUsed] = false;
 			vertices[key].invalidate();
@@ -163,12 +163,13 @@ function checkAllVisited(): void {
 }
 
 function checkVertices(ids: string[], nodeModulesPath: string): void {
-	let outputMessage: string | undefined;
 	const compilerOptions: TJS.CompilerOptions = {
 		baseUrl: nodeModulesPath,
 	};
 	const program: TJS.Program = TJS.getProgramFromFiles([path.join(nodeModulesPath, protocolSubPath)], compilerOptions);
-	const vertexSchema: TJS.Definition | null = TJS.generateSchema(program, 'Vertex', { required: true });
+	const schema: { [label: string]: TJS.Definition } = {};
+
+	let outputMessage: string | undefined;
 	let count: number = 1;
 	const length: number = ids.length;
 
@@ -178,27 +179,44 @@ function checkVertices(ids: string[], nodeModulesPath: string): void {
 		process.stdout.write(`${outputMessage}\r`);
 		count++;
 
-		const validation: ValidatorResult = validateSchema(vertex, vertexSchema);
-		if (!validation.valid) {
-			let errorMessage: string | undefined;
-			vertices[key].invalidate();
-
-			if (vertex.label === undefined) {
-				errorMessage = `requires property "label"`;
-			} else if (!Object.values(LSIF.VertexLabels).includes(vertex.label)) {
-				errorMessage = `unknown label`;
-			} else {
-				try {
-					const className: string = vertex.label[0].toUpperCase() + vertex.label.slice(1);
-					const specificSchema: TJS.Definition | null = TJS.generateSchema(program, className, { required: true });
-					const moreValidation: ValidatorResult | null = validateSchema(vertex, specificSchema);
-					errorMessage = moreValidation.errors.join('; ');
-				} catch {
-					// Failed to get more details for the error
-					errorMessage = 'unable to provide details';
+		let errorMessage: string;
+		if (vertex.label === undefined) {
+			errorMessage = `requires property "label"`;
+		} else if (!Object.values(LSIF.VertexLabels).includes(vertex.label)) {
+			errorMessage = `unknown label`;
+		} else {
+			try {
+				let className: string = '';
+				if (vertex.label === LSIF.VertexLabels.event) {
+					if (vertex.scope === undefined) {
+						errorMessage = `requires property "scope"`;
+					} else {
+						className = vertex.scope[0].toUpperCase() + vertex.scope.slice(1) + 'Event';
+					}
+				} else {
+					className = vertex.label[0].toUpperCase() + vertex.label.slice(1);
 				}
+
+				if (schema[className] === undefined) {
+					const specificSchema: TJS.Definition | null = TJS.generateSchema(program, className, { required: true });
+					if (specificSchema) {
+						schema[className] = specificSchema;
+					} else {
+						errorMessage = `did not find class ${className}`;
+					}
+				}
+
+				const validation: ValidatorResult | null = validateSchema(vertex, schema[className]);
+				if (!validation.valid) {
+					vertices[key].invalidate();
+					errorMessage = validation.errors.join('; ');
+					errors.push(new Error(vertex, errorMessage));
+				}
+			} catch {
+				vertices[key].invalidate();
+				errorMessage = `unable to validate`;
+				errors.push(new Error(vertex, errorMessage));
 			}
-			errors.push(new Error(vertex, errorMessage!));
 		}
 	});
 


### PR DESCRIPTION
### False invalids
Empty lines of input are now ignored.
"$event" labeled vertices are no longer considered invalid if not connected to any other vertex.

### Performance improvement
Schemas are now stored in a dictionary for re-use. Run time was drastically reduced. Example:

| Version | # Vertices | # Edges | Run time (mm:ss.fff) |
|---------|------------|---------|----------------------|
| 0.2.13  | 1608       | 1677    | 01:57.63            |
| 0.2.14  | 1608       | 1677    | 00:10.797             |

This PR also fixes an issue where `typescript-json-schema` could not validate some vertices and the tool would silently fail.