### PR TITLE
Fix scoped packages

### DIFF
--- a/npm/src/main.ts
+++ b/npm/src/main.ts
@@ -235,8 +235,9 @@ class ImportLinker extends Linker {
 			let part = parts[i];
 			if (part === 'node_modules') {
 				// End is exclusive and one for the name
-				packagePath = path.join(this.projectRoot, ...parts.slice(0, i + 2), `package.json`);
-				monikerPath = parts.slice(i + 2).join('/');
+				const packageIndex = i + (parts[i + 1].startsWith('@') ? 3 : 2)
+				packagePath = path.join(this.projectRoot, ...parts.slice(0, packageIndex), `package.json`);
+				monikerPath = parts.slice(packageIndex).join('/');
 				break;
 			}
 		}


### PR DESCRIPTION
Previously, packages such as `node_modules/@sourcegraph/lsp-client` were not being recognized in lsif-npm, preventing monikers from being generated for them.

This adds support for so called "scoped" packages which look like `@user/package`.

cc @dbaeumer @jumattos 