### PR TITLE
OS agnostic lsif-tsc docs

### DIFF
--- a/tsc/README.md
+++ b/tsc/README.md
@@ -13,4 +13,18 @@ See also the [Language Server Index Format Specification](https://github.com/Mic
 
 ### How to Run the Tool
 
-The easiest way to run the tool is to install the latest version (which are pre-release version starting with 0.x right now). For example `npm install -g lsif-tsc`. Then execute the command on a TypeScipt project using the following command `lsif-tsc -p .\tsconfig.json --stdout`. This print a LSIF dump to stdout. You might also want to execute `list-tsc --help` to get an overview of available command line options. Also of interest could be the overall [readme](https://github.com/microsoft/lsif-node/blob/master/README.md)
+The easiest way to run the tool is to install the latest version (which are pre-release version starting with 0.x right now):
+
+```
+npm install -g lsif-tsc
+```
+
+Then execute the command on a TypeScipt project using the following command:
+
+```
+lsif-tsc -p tsconfig.json --out=dump.lsif
+```
+
+This saves an LSIF dump to `dump.lsif`.
+
+You might also want to execute `list-tsc --help` to get an overview of available command line options. Also of interest could be the overall [readme](https://github.com/microsoft/lsif-node/blob/master/README.md)


### PR DESCRIPTION
@dbaeumer The backslash (for Windows) was causing a bit of confusion for developers on other OSs.
