### PR TITLE
Update packages getting flagged for security vulnerabilities

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -38,14 +38,14 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"npm": {
-			"version": "6.14.5",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-6.14.5.tgz",
-			"integrity": "sha512-CDwa3FJd0XJpKDbWCST484H+mCNjF26dPrU+xnREW+upR0UODjMEfXPl3bxWuAwZIX6c2ASg1plLO7jP8ehWeA==",
+			"version": "6.14.6",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-6.14.6.tgz",
+			"integrity": "sha512-axnz6iHFK6WPE0js/+mRp+4IOwpHn5tJEw5KB6FiCU764zmffrhsYHbSHi2kKqNkRBt53XasXjngZfBD3FQzrQ==",
 			"requires": {
 				"JSONStream": "^1.3.5",
 				"abbrev": "~1.1.1",
@@ -126,7 +126,7 @@
 				"npm-packlist": "^1.4.8",
 				"npm-pick-manifest": "^3.0.2",
 				"npm-profile": "^4.0.4",
-				"npm-registry-fetch": "^4.0.4",
+				"npm-registry-fetch": "^4.0.5",
 				"npm-user-validate": "~1.0.0",
 				"npmlog": "~4.1.2",
 				"once": "~1.4.0",
@@ -1999,7 +1999,7 @@
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "4.0.4",
+					"version": "4.0.5",
 					"bundled": true,
 					"requires": {
 						"JSONStream": "^1.3.4",
@@ -2012,7 +2012,7 @@
 					},
 					"dependencies": {
 						"safe-buffer": {
-							"version": "5.2.0",
+							"version": "5.2.1",
 							"bundled": true
 						}
 					}
@@ -2675,7 +2675,7 @@
 					}
 				},
 				"spdx-license-ids": {
-					"version": "3.0.3",
+					"version": "3.0.5",
 					"bundled": true
 				},
 				"split-on-first": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -17,10 +17,10 @@
 		"lsif-npm": "./bin/lsif-npm"
 	},
 	"dependencies": {
-		"minimist": "^1.2.0",
-		"uuid": "^7.0.2",
 		"lsif-protocol": "0.5.0-next.3",
 		"lsif-tsc": "0.5.0-next.1",
+		"minimist": "^1.2.5",
+		"uuid": "^7.0.2",
 		"vscode-uri": "^2.1.1"
 	},
 	"devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
 			"dev": true
 		},
 		"log-symbols": {
@@ -1176,18 +1176,18 @@
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
+				"minimist": "^1.2.5"
 			}
 		},
 		"mocha": {

--- a/tsc/package-lock.json
+++ b/tsc/package-lock.json
@@ -46,14 +46,14 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"npm": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-6.14.2.tgz",
-			"integrity": "sha512-eBVjzvGJ9v2/jRJZFtIkvUVKmJ0sCJNNwc9Z1gI6llwaT7EBYWJe5o61Ipc1QR0FaDCKM3l1GizI09Ro3STJEw==",
+			"version": "6.14.6",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-6.14.6.tgz",
+			"integrity": "sha512-axnz6iHFK6WPE0js/+mRp+4IOwpHn5tJEw5KB6FiCU764zmffrhsYHbSHi2kKqNkRBt53XasXjngZfBD3FQzrQ==",
 			"requires": {
 				"JSONStream": "^1.3.5",
 				"abbrev": "~1.1.1",
@@ -84,7 +84,7 @@
 				"fs-write-stream-atomic": "~1.0.10",
 				"gentle-fs": "^2.3.0",
 				"glob": "^7.1.6",
-				"graceful-fs": "^4.2.3",
+				"graceful-fs": "^4.2.4",
 				"has-unicode": "~2.0.1",
 				"hosted-git-info": "^2.8.8",
 				"iferr": "^1.0.2",
@@ -121,10 +121,10 @@
 				"lru-cache": "^5.1.1",
 				"meant": "~1.0.1",
 				"mississippi": "^3.0.0",
-				"mkdirp": "~0.5.1",
+				"mkdirp": "^0.5.5",
 				"move-concurrently": "^1.0.1",
 				"node-gyp": "^5.1.0",
-				"nopt": "~4.0.1",
+				"nopt": "^4.0.3",
 				"normalize-package-data": "^2.5.0",
 				"npm-audit-report": "^1.3.2",
 				"npm-cache-filename": "~1.0.2",
@@ -134,7 +134,7 @@
 				"npm-packlist": "^1.4.8",
 				"npm-pick-manifest": "^3.0.2",
 				"npm-profile": "^4.0.4",
-				"npm-registry-fetch": "^4.0.3",
+				"npm-registry-fetch": "^4.0.5",
 				"npm-user-validate": "~1.0.0",
 				"npmlog": "~4.1.2",
 				"once": "~1.4.0",
@@ -155,7 +155,7 @@
 				"readdir-scoped-modules": "^1.1.0",
 				"request": "^2.88.0",
 				"retry": "^0.12.0",
-				"rimraf": "^2.6.3",
+				"rimraf": "^2.7.1",
 				"safe-buffer": "^5.1.2",
 				"semver": "^5.7.1",
 				"sha": "^3.0.0",
@@ -684,7 +684,7 @@
 					"bundled": true
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true
 				},
 				"defaults": {
@@ -1163,7 +1163,7 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.3",
+					"version": "4.2.4",
 					"bundled": true
 				},
 				"har-schema": {
@@ -1314,10 +1314,10 @@
 					"bundled": true
 				},
 				"is-ci": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"requires": {
-						"ci-info": "^1.0.0"
+						"ci-info": "^1.5.0"
 					},
 					"dependencies": {
 						"ci-info": {
@@ -1379,7 +1379,7 @@
 					}
 				},
 				"is-retry-allowed": {
-					"version": "1.1.0",
+					"version": "1.2.0",
 					"bundled": true
 				},
 				"is-stream": {
@@ -1792,10 +1792,6 @@
 						"brace-expansion": "^1.1.7"
 					}
 				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true
-				},
 				"minizlib": {
 					"version": "1.3.3",
 					"bundled": true,
@@ -1830,10 +1826,16 @@
 					}
 				},
 				"mkdirp": {
-					"version": "0.5.1",
+					"version": "0.5.5",
 					"bundled": true,
 					"requires": {
-						"minimist": "0.0.8"
+						"minimist": "^1.2.5"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.5",
+							"bundled": true
+						}
 					}
 				},
 				"move-concurrently": {
@@ -1893,7 +1895,7 @@
 					}
 				},
 				"nopt": {
-					"version": "4.0.1",
+					"version": "4.0.3",
 					"bundled": true,
 					"requires": {
 						"abbrev": "1",
@@ -2005,7 +2007,7 @@
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "4.0.3",
+					"version": "4.0.5",
 					"bundled": true,
 					"requires": {
 						"JSONStream": "^1.3.4",
@@ -2018,7 +2020,7 @@
 					},
 					"dependencies": {
 						"safe-buffer": {
-							"version": "5.2.0",
+							"version": "5.2.1",
 							"bundled": true
 						}
 					}
@@ -2384,17 +2386,17 @@
 					"bundled": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
-							"version": "1.2.0",
+							"version": "1.2.5",
 							"bundled": true
 						}
 					}
@@ -2466,7 +2468,7 @@
 					}
 				},
 				"registry-auth-token": {
-					"version": "3.3.2",
+					"version": "3.4.0",
 					"bundled": true,
 					"requires": {
 						"rc": "^1.1.6",
@@ -2523,7 +2525,7 @@
 					"bundled": true
 				},
 				"rimraf": {
-					"version": "2.6.3",
+					"version": "2.7.1",
 					"bundled": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -2681,7 +2683,7 @@
 					}
 				},
 				"spdx-license-ids": {
-					"version": "3.0.3",
+					"version": "3.0.5",
 					"bundled": true
 				},
 				"split-on-first": {
@@ -3060,7 +3062,7 @@
 					}
 				},
 				"widest-line": {
-					"version": "2.0.0",
+					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
 						"string-width": "^2.1.1"

--- a/tsc/package.json
+++ b/tsc/package.json
@@ -18,11 +18,11 @@
 	},
 	"dependencies": {
 		"lsif-protocol": "0.5.0-next.3",
-		"minimist": "^1.2.0",
-		"npm": "^6.14.2",
+		"minimist": "^1.2.5",
+		"npm": "^6.14.6",
+		"typescript": "https://github.com/dbaeumer/TypeScript/releases/download/3.8.3-lsif/typescript-3.8.3-lsif.tgz",
 		"uuid": "^7.0.2",
-		"vscode-uri": "^2.1.1",
-		"typescript": "https://github.com/dbaeumer/TypeScript/releases/download/3.8.3-lsif/typescript-3.8.3-lsif.tgz"
+		"vscode-uri": "^2.1.1"
 	},
 	"devDependencies": {
 		"@types/minimist": "^1.2.0",


### PR DESCRIPTION
In our CI pipeline, we have a task that flags dependencies with known security vulnerabilities. I ran `npm audit fix` to fix any such vulnerabilities in the lsif-npm and lsif-tsc packages