### PR TITLE
lsif-util: Fix #70 by replacing \\" with \" in vertex extra info sections

### DIFF
--- a/util/example/line.json
+++ b/util/example/line.json
@@ -1,7 +1,8 @@
 { "id": 1, "type": "vertex", "label": "document", "contents": "THISTERRIBLESTRINGISLONGANDUGLYANDWEDONTWANTTOSEEITINOURGRAPHNOMATTERWHAT" }
-{ "id": 2, "type": "vertex", "label": "range" }
-{ "id": 3, "type": "vertex", "label": "range", "tag": { "text": "foo" } }
-{ "id": 4, "type": "edge", "label": "contains", "outV": 1, "inV": 2 }
-{ "id": 5, "type": "edge", "label": "contains", "outV": 1, "inVs": [ 3 ] }
-{ "id": 6, "type": "vertex", "label": "referenceResult" }
-{ "id": 7, "type": "edge", "label": "item", "property": "references", "outV": 6, "inVs": [ 3 ], "document": "1" }
+{ "id": 2, "type": "vertex", "label": "hoverResult", "result": { "contents": [ { "language": "go", "value": "package \"fmt\""}, "fmt.Printf(\"%v\\n\", i)"] }}
+{ "id": 3, "type": "vertex", "label": "range" }
+{ "id": 4, "type": "vertex", "label": "range", "tag": { "text": "foo" } }
+{ "id": 5, "type": "edge", "label": "contains", "outV": 1, "inV": 2 }
+{ "id": 6, "type": "edge", "label": "contains", "outV": 1, "inVs": [ 3 ] }
+{ "id": 7, "type": "vertex", "label": "referenceResult" }
+{ "id": 8, "type": "edge", "label": "item", "property": "references", "outV": 6, "inVs": [ 3 ], "document": "1" }

--- a/util/src/visualize.ts
+++ b/util/src/visualize.ts
@@ -76,7 +76,8 @@ function printDOT(edges: { [id: string]: LSIF.Element }, vertices: { [id: string
 			const value: string = JSON.stringify((extraInfo as any)[property]);
 			const re: RegExp = new RegExp('"', 'g');
       extraText += `\n${property} = ${value.replace(re, '\\"')}`;
-      extraText = extraText.replace(/\\\\"/g, '\\"');
+      const reEscaped: RegExp = new RegExp('\\\\\\\\"', 'g')
+      extraText = extraText.replace(reEscaped, '\\"');
 		});
 
 		digraph += `  ${vertex.id} [label="[${vertex.id}] ${vertex.label}${extraText}"]\n`;

--- a/util/src/visualize.ts
+++ b/util/src/visualize.ts
@@ -75,7 +75,8 @@ function printDOT(edges: { [id: string]: LSIF.Element }, vertices: { [id: string
 		Object.keys(extraInfo).forEach((property: string) => {
 			const value: string = JSON.stringify((extraInfo as any)[property]);
 			const re: RegExp = new RegExp('"', 'g');
-			extraText += `\n${property} = ${value.replace(re, '\\"')}`;
+      extraText += `\n${property} = ${value.replace(re, '\\"')}`;
+      extraText = extraText.replace(/\\\\"/g, '\\"');
 		});
 
 		digraph += `  ${vertex.id} [label="[${vertex.id}] ${vertex.label}${extraText}"]\n`;


### PR DESCRIPTION
Cases where extra text would already contain an escaped double quote would result in the \ being escaped, causing the double quote to interfere with graphdot 
Closes #70 

Not tested on a variety of inputs yet, if more validation is preferred ye can hold off on merging this