### PR TITLE
Allow project's `name` property to be optional.

### DIFF
--- a/protocol/src/protocol.ts
+++ b/protocol/src/protocol.ts
@@ -1046,7 +1046,7 @@ export namespace Project {
 	export const descriptor = new VertexDescriptor<Project>(Object.assign({}, V.descriptor.description, {
 		label: VertexLabels.property(VertexLabels.project),
 		kind: new StringProperty(),
-		name: new StringProperty(),
+		name: new StringProperty(PropertyFlags.optional),
 		resource: new UriProperty(PropertyFlags.optional),
 		contents: new StringProperty(PropertyFlags.optional)
 	}));


### PR DESCRIPTION
- `name` became required in order to aid debugging; however, given the nature of "improving debugging" it feels more like an optional parameter.