### PR TITLE
Fix free range validation for delayed `contains` nodes.

### DIFF
--- a/protocol/src/protocol.ts
+++ b/protocol/src/protocol.ts
@@ -1046,7 +1046,7 @@ export namespace Project {
 	export const descriptor = new VertexDescriptor<Project>(Object.assign({}, V.descriptor.description, {
 		label: VertexLabels.property(VertexLabels.project),
 		kind: new StringProperty(),
-		name: new StringProperty(),
+		name: new StringProperty(PropertyFlags.optional),
 		resource: new UriProperty(PropertyFlags.optional),
 		contents: new StringProperty(PropertyFlags.optional)
 	}));

--- a/tsc-tests/src/csharpTests.ts
+++ b/tsc-tests/src/csharpTests.ts
@@ -1,0 +1,78 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { assertValid } from './lsifs';
+
+suite('C# Tests', () => {
+
+	test('Two related classes', async () => {
+		/**
+		 * This test consumes a C# LSIF file that's from a net6.0 Hello World project:
+		 * 
+		 * ----- Structure -----
+		 * HelloWorld/
+		 * 		obj/Debug/net6.0
+		 * 			- HelloWorld.GlobalUsings.g.cs
+		 * 			- HelloWorld.AssemblyInfo.cs
+		 *			- .NETCoreApp,Version=v6.0.AssemblyAttributes.cs
+		 * 		- HelloWorld.csproj
+		 * 		- Person.cs
+		 * 		- House.cs
+		 * 
+		 * ----- Person.cs -----
+		 * using System.Text;
+		 * 
+		 * namespace SampleLibrary
+		 * {
+		 * 	public class Person
+		 * 	{
+		 * 		public string Name { get; set; } = default!;
+		 * 
+		 * 		public Person Parent { get; set; } = default!;
+		 * 
+		 * 		public void AppendTo(StringBuilder builder)
+		 * 		{
+		 * 			builder.Append(Name);
+		 * 
+		 * 			if (Parent is not null)
+		 * 			{
+		 * 				builder.Append(" <- ");
+		 * 				Parent.AppendTo(builder);
+		 * 			}
+		 * 			else
+		 * 			{
+		 * 				builder.AppendLine();
+		 * 			}
+		 * 		}
+		 * 	}
+		 * }
+		 * 
+		 * ----- House.cs -----
+		 * using System.Text;
+		 * 
+		 * namespace SampleLibrary
+		 * {
+		 * 	public class House
+		 * 	{
+		 * 		public string Address { get; set; } = default!;
+		 * 
+		 * 		public IReadOnlyList<Person> People { get; set; } = default!;
+		 * 
+		 * 		public void AppendTo(StringBuilder builder)
+		 * 		{
+		 * 			builder.AppendLine("Address: " + Address);
+		 * 			builder.AppendLine("-------------------");
+		 * 			for (var i = 0; i < People.Count; i++)
+		 * 			{
+		 * 				People[i].AppendTo(builder);
+		 * 			}
+		 * 		}
+		 * 	}
+		 * }
+		 */
+
+		await assertValid('outputs/twoRelatedClasses.lsif');
+	});
+});

--- a/tsc-tests/src/lsifs.ts
+++ b/tsc-tests/src/lsifs.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
+import * as fs from 'fs';
 
 import { URI } from 'vscode-uri';
 
@@ -27,6 +28,16 @@ export function assertElement(actual: Element | undefined, expected: Element): v
 		actual.identifier = '*';
 	}
 	assert.deepEqual(actual, expected);
+}
+
+export async function assertValid(inputFilePath: string): Promise<void> {
+	const inputFile = fs.createReadStream(inputFilePath, { encoding: 'utf8'});
+	const testReporter = new TestDiagnosticReporter();
+	const validate: ValidateCommand = new ValidateCommand(inputFile, {}, testReporter);
+	await validate.run();
+	if (testReporter.buffer.length !== 0) {
+		throw new Error(`Validation failed:${os.EOL}${testReporter.buffer.join(os.EOL)}`);
+	}
 }
 
 class TestDiagnosticReporter implements DiagnosticReporter {


### PR DESCRIPTION
- In scenarios where `contains` nodes would occur post-item nodes our validator would explode because it'd validate `item` nodes at their time of occurrence. Meaning if you had:
```
...
{ "label":"item" .... "inVs":[123] }
...
{ "label":"contains" .... "inVs":[123] }
...
```
We'd validate the `item` node and see if there was a `contains` node that mentioned it's `inVs`.

- This changeset adds a new `postValidate` path and changes the existing validate interactions to pass multiple elements (instead of one at a time) so we can ensure that we've iterated over the entire set prior to callign `postValidate`
	- Ultimately this is how C#'s LSIF generator operates which led me to this `validate` interaction.
- Added a test for C# specific files that takes in a C# LSIF file and validates that no validation errors have occurred.