### PR TITLE
Normalize URI in JSON store. Update sqlite to 10.7.0

### DIFF
--- a/language-service/package-lock.json
+++ b/language-service/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/lsif-language-service",
-	"version": "0.1.0-pre.2",
+	"version": "0.1.0-pre.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/lsif-language-service",
-			"version": "0.1.0-pre.2",
+			"version": "0.1.0-pre.3",
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/lsif-protocol": "0.6.0-next.8",

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@vscode/lsif-language-service",
 	"description": "LSIF based language services",
-	"version": "0.1.0-pre.2",
+	"version": "0.1.0-pre.3",
 	"author": "Microsoft Corporation",
 	"license": "MIT",
 	"repository": {

--- a/language-service/src/jsonStore.ts
+++ b/language-service/src/jsonStore.ts
@@ -235,6 +235,8 @@ export class JsonStore extends Database {
 	}
 
 	private doProcessDocument(document: Document): void {
+		// Normalize the document uri to the format used in VS Code.
+		document.uri = URI.parse(document.uri).toString(true);
 		const contents = document.contents !== undefined ? document.contents : 'No content provided.';
 		this.vertices.documents.set(document.id, document);
 		const hash = crypto.createHash('md5').update(contents).digest('base64');

--- a/language-service/src/tests/jsonTests.ts
+++ b/language-service/src/tests/jsonTests.ts
@@ -41,7 +41,7 @@ suite('Rust dump', async () => {
 		assert.strictEqual(store.getWorkspaceRoot().toString(true), 'file:///c:/fixtures/fix-test-failure/case9');
 		const documents = store.getDocumentInfos();
 		assert.strictEqual(documents.length, 2);
-		assert.strictEqual(documents[0].uri.toString(), 'file:///c:/fixtures/fix-test-failure/case9/src/lib.rs');
-		assert.strictEqual(documents[1].uri.toString(), 'file:///c:/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/src/rust/library/core/src/macros/mod.rs');
+		assert.strictEqual(documents[0].uri, 'file:///c:/fixtures/fix-test-failure/case9/src/lib.rs');
+		assert.strictEqual(documents[1].uri, 'file:///c:/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/src/rust/library/core/src/macros/mod.rs');
 	});
 });

--- a/language-service/src/tests/jsonTests.ts
+++ b/language-service/src/tests/jsonTests.ts
@@ -28,3 +28,20 @@ suite('JSON Dump', async () => {
 		assert.strictEqual(references!.length, 10);
 	});
 });
+
+suite('Rust dump', async () => {
+	let store: JsonStore;
+
+	setup(async () => {
+		store = new JsonStore();
+		await store.load(path.join(__dirname, '..', '..', 'src', 'tests', 'rust.lsif'));
+	});
+
+	test('Normalized URIs', async() => {
+		assert.strictEqual(store.getWorkspaceRoot().toString(true), 'file:///c:/fixtures/fix-test-failure/case9');
+		const documents = store.getDocumentInfos();
+		assert.strictEqual(documents.length, 2);
+		assert.strictEqual(documents[0].uri.toString(), 'file:///c:/fixtures/fix-test-failure/case9/src/lib.rs');
+		assert.strictEqual(documents[1].uri.toString(), 'file:///c:/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/src/rust/library/core/src/macros/mod.rs');
+	});
+});

--- a/sqlite/package.json
+++ b/sqlite/package.json
@@ -17,7 +17,7 @@
 		"lsif-sqlite": "./bin/lsif-sqlite"
 	},
 	"dependencies": {
-		"better-sqlite3": "^11.0.0",
+		"better-sqlite3": "10.7.0",
 		"lsif-protocol": "0.6.0-next.7",
 		"uuid": "^10.0.0",
 		"vscode-uri": "^3.0.8",


### PR DESCRIPTION
This pull request includes changes to normalize the URI format used in the JSON store and updates the sqlite dependency to version 10.7.0. The normalization of the URI ensures consistency with the format used in VS Code.